### PR TITLE
Handle marking time entries as billable

### DIFF
--- a/fbtimer/model/project.py
+++ b/fbtimer/model/project.py
@@ -11,6 +11,10 @@ class Project(BaseModel):
         return self.raw_data.get('client_id')
 
     @property
+    def billable(self):
+        return self.raw_data.get('project_type') != 'fixed_price'
+
+    @property
     def services(self):
         return [Service(a) for a in self.raw_data.get('services')]
 

--- a/fbtimer/model/timer.py
+++ b/fbtimer/model/timer.py
@@ -41,6 +41,7 @@ class Timer(BaseModel):
         for time_entry in self.raw_data.get('time_entries'):
             if not time_entry.get('duration'):
                 return time_entry
+        return self.raw_data.get('time_entries')[-1]
 
     @property
     def start_time(self):
@@ -76,3 +77,12 @@ class Timer(BaseModel):
     @property
     def note(self):
         return self.raw_data.get('time_entries')[-1].get('note')
+
+    @property
+    def billable(self):
+        return self.raw_data.get('time_entries')[-1].get('billable')
+
+    def billable_msg(self):
+        if self.billable:
+            return 'billable'
+        return 'not billable'

--- a/fbtimer/service/time_entry.py
+++ b/fbtimer/service/time_entry.py
@@ -13,9 +13,6 @@ def create_new_time_entry(user, timer=None):
     time_entry = {
         'time_entry': {
             'is_logged': False,
-            # 'note': 'Stuff',
-            # 'client_id': '2149780',\
-            # 'project_id': '153125'\
             'started_at': zulu_time(datetime.utcnow())
         }
     }
@@ -59,7 +56,7 @@ def pause_time_entry(user, timer):
 
 
 def update_time_entry(user, timer, client_id=None, internal_client=False,
-                      project_id=None, service_id=None, note=None):
+                      project=None, change_billable=False, service_id=None, note=None):
     active_time_entry = timer.active_time_entry
 
     if client_id:
@@ -67,12 +64,18 @@ def update_time_entry(user, timer, client_id=None, internal_client=False,
     elif internal_client:
         active_time_entry['client_id'] = None
         active_time_entry['internal'] = True
-    if project_id:
-        active_time_entry['project_id'] = project_id
+    if project:
+        active_time_entry['project_id'] = project.id
+        if not project.billable:
+            active_time_entry['billable'] = False
     if service_id:
         active_time_entry['service_id'] = service_id
+    if change_billable:
+        active_time_entry['billable'] = not active_time_entry['billable']
     if note:
         active_time_entry['note'] = note
+    if not timer.is_running:
+        active_time_entry['timer'] = {'id': timer.id}
 
     time_entry = {
         'time_entry': active_time_entry

--- a/tests/component/test_timer_details.py
+++ b/tests/component/test_timer_details.py
@@ -11,7 +11,8 @@ from tests import get_fixture
 
 
 class DetailsTests(unittest.TestCase):
-    UPDATE_TEXT = 'Update:\n1. Client\n2. Project\n3. Service\n4. Note\n0. Quit\n'
+    UPDATE_TEXT = ('Update:\n1. Client\n2. Project\n3. Service\n4. Billable\n'
+                   '5. Note\n0. Quit\n')
     RECENT_CLIENTS_TEXT = (
         'Recent Clients:\n'
         '1. Internal (My Business)\n'
@@ -341,7 +342,7 @@ class DetailsTests(unittest.TestCase):
         )
 
         runner = CliRunner()
-        result = runner.invoke(cli, ['details'], input='4\nI added a note right here\n0\n')
+        result = runner.invoke(cli, ['details'], input='5\nI added a note right here\n0\n')
 
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(


### PR DESCRIPTION
Added to details menu.
This also fixes an error when selecting a flat-rate project when the
time entry is marked as billable.

Also now handling setting details on a paused timer.